### PR TITLE
LivenessServer in separate file, http in test

### DIFF
--- a/livenessserver.py
+++ b/livenessserver.py
@@ -1,0 +1,36 @@
+import http.server
+import sys
+import threading
+import os
+import json
+import time
+import os
+
+class LivenessServer(http.server.BaseHTTPRequestHandler):
+    ready = True
+
+    def do_GET(s):
+        if s.path == '/health/alive':
+            s.liveness_check()
+        elif s.path == '/health/ready':
+            s.readiness_check()
+
+    def liveness_check(s):
+        s.send_response(200)
+        s.send_header('Content-Type', 'text/html')
+        s.end_headers()
+        s.wfile.write(b'''Ok.''')
+
+    def readiness_check(s):
+        if s.ready:
+            s.send_response(200)
+            s.send_header('Content-Type', 'text/plain')
+            s.end_headers()
+            s.wfile.write(b'''Ok.''')
+        else:
+            # The actual response does not really matter, as long as it's not
+            # a HTTP 200 status.
+            s.send_response(503)
+            s.send_header('Content-Type', 'text/plain')
+            s.end_headers()
+            s.wfile.write(b'''Not ready yet.''')

--- a/metrics.py
+++ b/metrics.py
@@ -1,80 +1,53 @@
-from atlassian import Jira
-import prometheus_client as prom
-from google.cloud import secretmanager
+from os import getenv
 import google.auth
+from google.cloud import secretmanager
 import http.server
 import signal
-import sys
-import threading
-import os
-import json
-import time
-
-# Get credenetials from Workload Identity
-credentials = google.auth.default()
-
-# Create client for secret manager
-client = secretmanager.SecretManagerServiceClient()
-
-# Fetch secret from secret manager
-name = client.secret_version_path('ssb-team-stratus', 'jira-api-key', 'latest')
-response = client.access_secret_version(name)
-api_key = response.payload.data
+from atlassian import Jira
+import prometheus_client as prom
+from livenessserver import LivenessServer
 
 
-def jira():
-    jira_conn = Jira(
+def getApiKey():
+    # Get credenetials from Workload Identity
+    credentials = google.auth.default()
+    # Create client for secret manager
+    client = secretmanager.SecretManagerServiceClient()
+    # Fetch secret from secret manager
+    name = client.secret_version_path('ssb-team-stratus', 'jira-api-key', 'latest')
+    response = client.access_secret_version(name)
+    return response.payload.data
+
+apiKey = getApiKey()
+
+def getJiraConnection():
+    return Jira(
         url='https://statistics-norway.atlassian.net',
         username='egk@ssb.no',
-        password=api_key)
-    jql = 'project = BIP AND status IN ("To Do", "In Progress")'
-    data = jira_conn.jql(jql)
-    return data.get("total")
+        password=apiKey)
 
+jira_conn = getJiraConnection()
 
-class MyWebpage(http.server.BaseHTTPRequestHandler):
-    ready = True
+def queryJira(jql, jira_conn, limitResults='None'):
+    return jira_conn.jql(jql,limit=limitResults)
 
-
-    def do_GET(s):
-        if s.path == '/health/alive':
-            s.liveness_check()
-        elif s.path == '/health/ready':
-            s.readiness_check()
-
-    def liveness_check(s):
-        s.send_response(200)
-        s.send_header('Content-Type', 'text/html')
-        s.end_headers()
-        s.wfile.write(b'''Ok.''')
-
-    def readiness_check(s):
-        if s.ready:
-            s.send_response(200)
-            s.send_header('Content-Type', 'text/plain')
-            s.end_headers()
-            s.wfile.write(b'''Ok.''')
-        else:
-            # The actual response does not really matter, as long as it's not
-            # a HTTP 200 status.
-            s.send_response(503)
-            s.send_header('Content-Type', 'text/plain')
-            s.end_headers()
-            s.wfile.write(b'''Not ready yet.''')
-
+def getTotalUnsolved():
+    jql = 'project = BIP AND status IN ("To Do", "Selected for development","In Progress", "QA")'
+    limit = 0 # Only return metainformation, no acutal issues
+    return queryJira(jql, jira_conn, limit).get('total')
 
 if __name__ == '__main__':
     # First we collect the environment variables that were set in either
     # the Dockerfile or the Kubernetes Pod specification.
-    listen_port = int(os.getenv('LISTEN_PORT', 8090))
-    prom_listen_port = int(os.getenv('PROM_LISTEN_PORT', 8080))
+    listen_port = int(getenv('LISTEN_PORT', 8090))
+    prom_listen_port = int(getenv('PROM_LISTEN_PORT', 8080))
 
     gauge = prom.Gauge('jira_bip_active_issues', 'Backlog and active')
-    gauge.set(jira())
+    gauge.set(getTotalUnsolved())
     # Let the Prometheus client export its metrics on a separate port.
     prom.start_http_server(prom_listen_port)
     # Let our web application run and listen on the specified port.
-    httpd = http.server.HTTPServer(('localhost', listen_port), MyWebpage)
+    httpd = http.server.HTTPServer(('localhost', listen_port), LivenessServer)
     # Make sure you have the webserver signal when it's done.
     httpd.ready = True
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 -i https://pypi.org/simple
 atlassian-python-api==1.16.0
+attrs==19.3.0
 cachetools==4.1.1
 certifi==2020.6.20
 chardet==3.0.4
@@ -10,14 +11,27 @@ googleapis-common-protos[grpc]==1.52.0
 grpc-google-iam-v1==0.12.3
 grpcio==1.30.0
 idna==2.10
+importlib-metadata==1.7.0 ; python_version < '3.8'
+iniconfig==1.0.1
+more-itertools==8.4.0
 oauthlib==3.1.0
+packaging==20.4
+pluggy==0.13.1
 prometheus-client==0.8.0
 protobuf==3.12.2
+py==1.9.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
+pyparsing==2.4.7
+pytest-curl-report==0.5.4
+pytest-httpserver==0.3.4
+pytest==6.0.1
 pytz==2020.1
 requests-oauthlib==1.3.0
 requests==2.24.0
-rsa==4.6 ; python_version >= '3'
+rsa==4.6
 six==1.15.0
+toml==0.10.1
 urllib3==1.25.10
+werkzeug==1.0.1
+zipp==3.1.0

--- a/test_jira-metrics.py
+++ b/test_jira-metrics.py
@@ -1,0 +1,15 @@
+import metrics
+import requests
+from unittest import mock
+
+@mock.patch('metrics.getApiKey')
+def test_getApiKey(mock_apikey):
+    mock_apikey.return_value = "krabbegurgel"
+    result = metrics.getApiKey()
+    return result
+
+assert test_getApiKey() == "krabbegurgel"
+
+def test_json_client(httpserver):
+    httpserver.expect_request("/foobar").respond_with_json({"foo": "bar"})
+    assert requests.get(httpserver.url_for("/foobar")).json() == {'foo': 'bar'}


### PR DESCRIPTION
Why:

* The main code was a bit bloated, and difficult to unittest

This change addresses the need by:

* Splitting the liveness-server to separate module
* Installing pytest httpserver
* Splitting function to get Jira-connection from searching
* Introducing parameter to limit returned issues