### PR TITLE
Add doc about authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # jira-metrics-python
 Python application to expose metrics from Jira to Prometheus
+
+The application utilizes Workload Indentity to authorize itself and fetch the necessary API key to contact Jira. The Workload Identity service account is given read access to the necessary secret in Secret Manager.

--- a/metrics.py
+++ b/metrics.py
@@ -24,7 +24,7 @@ def getApiKey():
         response = client.access_secret_version(name)
         apiKey = response.payload.data
     except:
-        print("Could not get apiKey for Google Secret Manager", file=sys.stderr)
+        print("Could not get apiKey from Google Secret Manager", file=sys.stderr)
         apiKey = None
     return apiKey
 


### PR DESCRIPTION
This change contains a small correction in the code, in addition to
improved documentation about how the application utilizes Workload
Identity to fetch the secret API key for Jira access from Secret

int.ref:[BIP-1063]