### PR TITLE
Update metric strings

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -16,7 +16,7 @@ async def getJiraCollector():
 async def metrics(request):
     metricsDict = await getJiraCollector()
     metricsStr = str(metricsDict)
-    metricsStrReplaced = metricsStr[1:-1].replace('\'', '').replace('"', "'").replace(": ", " ").replace(",", "\n").replace(" j", "j")
+    metricsStrReplaced = metricsStr[1:-1].replace('\'', '').replace(': "', ' ').replace('0"', '0').replace(",", "\n").replace(" j", "j")
     return web.Response(text=metricsStrReplaced)
 
 


### PR DESCRIPTION
Why:

* The previous strings did not register as values in Prometheus

This change addresses the need by:

* Changing formatting of the metric strings

int.ref: [BIP-1154]