### PR TITLE
Decouple metrics collection from scraping

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -1,61 +1,52 @@
 import asyncio
 import logging
 import json
+import sys
+from apscheduler.schedulers.background import BackgroundScheduler
 from aiohttp import web
-from aiocache import cached
-from aiocache.serializers import JsonSerializer
 from jiracollector import JiraCollector
+from datetime import datetime
 
+cachedMetrics = ""
+serviceIsReady = False
 
-@cached(ttl=45, key="function_key", serializer=JsonSerializer())
-async def getJiraCollector():
+def collectJiraMetrics():
+    global cachedMetrics
+    global serviceIsReady
+    print("Running async")
+
     jiraCollector = JiraCollector()
-    return jiraCollector.collect()
-
-
-async def metrics(request):
-    metricsDict = await getJiraCollector()
+    metricsDict = jiraCollector.collect()
     metricsStr = str(metricsDict)
     metricsStrReplaced = metricsStr[1:-1].replace("'", "").replace(':', '').replace(",", "\n").replace(" j", "j") + "\n"
-    return web.Response(text=metricsStrReplaced)
+    cachedMetrics = metricsStrReplaced
+    serviceIsReady = True
 
-
-# It is also possible to cache the whole route, but for this you will need to
-# override `cached.get_from_cache` and regenerate the response since aiohttp
-# forbids reusing responses
-class CachedOverride(cached):
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-
-    async def get_from_cache(self, key):
-        try:
-            value = await self.cache.get(key)
-            if type(value) == web.Response:
-                return web.Response(
-                    body=value.body,
-                    status=value.status,
-                    reason=value.reason,
-                    headers=value.headers,
-                )
-            return value
-        except Exception:
-            logging.exception("Couldn't retrieve %s, unexpected error", key)
+def metrics(request):
+    global cachedMetrics
+    return web.Response(text=cachedMetrics)
 
 def alive(request):
     return web.Response(status=200, text="OK")
 
 def ready(request):
-    ready = True
-    if ready:
+    global serviceIsReady
+    if serviceIsReady:
         return web.Response(status=200, text="OK")
     else:
         return web.Response(status=503, text="Not ready yet")
 
 
 if __name__ == "__main__":
+    # Create a background thread to collect metrics in a "cache"
+    scheduler = BackgroundScheduler()
+    job = scheduler.add_job(collectJiraMetrics, 'interval', minutes=5,max_instances=1,next_run_time=datetime.now())
+    scheduler.start()
+    
+    # Create a webapp to serve cached metrics on / endpoint
     app = web.Application()
     app.router.add_get('/', metrics)
     app.router.add_get('/health/ready', ready)
-    app.router.add_get('/health/alive', ready)
+    app.router.add_get('/health/alive', alive)
 
     web.run_app(app)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 -i https://pypi.org/simple
 aiocache==0.11.1
 aiohttp==3.6.2
-async-timeout==3.0.1; python_full_version >= '3.5.3'
+apscheduler==3.6.3
+async-timeout==3.0.1
+asyncio==3.4.3
 atlassian-python-api==1.16.0
-attrs==20.1.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+attrs==20.1.0
 cachetools==4.1.1
 certifi==2020.6.20
 chardet==3.0.4
@@ -14,26 +16,30 @@ googleapis-common-protos[grpc]==1.52.0
 grpc-google-iam-v1==0.12.3
 grpcio==1.30.0
 idna==2.10
+importlib-metadata==1.7.0; python_version < '3.8'
 iniconfig==1.0.1
-more-itertools==8.4.0; python_version >= '3.5'
-multidict==4.7.6; python_version >= '3.5'
+more-itertools==8.4.0
+multidict==4.7.6
 oauthlib==3.1.0
 packaging==20.4; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
-pluggy==0.13.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pluggy==0.13.1
 protobuf==3.12.2
-py==1.9.0; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
+py==1.9.0
 pyasn1-modules==0.2.8
 pyasn1==0.4.8
-pyparsing==2.4.7; python_version >= '2.6' and python_version not in '3.0, 3.1, 3.2, 3.3'
+pyparsing==2.4.7
 pytest-curl-report==0.5.4
 pytest-httpserver==0.3.5
-pytest==6.0.1; python_version >= '3.5'
+pytest==6.0.1
 pytz==2020.1
 requests-oauthlib==1.3.0
 requests==2.24.0
 rsa==4.6
 six==1.15.0
 toml==0.10.1
+typing-extensions==3.7.4.3; python_version < '3.8'
+tzlocal==2.1
 urllib3==1.25.10
-werkzeug==1.0.1; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'
-yarl==1.5.1; python_version >= '3.5'
+werkzeug==1.0.1
+yarl==1.5.1
+zipp==3.1.0; python_version >= '3.6'


### PR DESCRIPTION
This commit decouples the collecting of metrics from the scraping
perfomed by Prometheus. This is achieved by running a background
thread wich collects the metrics from Jira and stores it in a global
datastructure. When the root context is queried this datastructure is
simply returned. The background job is, as of now, configured to run
every 5 minutes.

The metrics removed in previous commits are reinstated.

Co-authored-by: @are3k
Co-authored-by: @ArielKarlsen